### PR TITLE
Track device properties on A/B experiment's membership

### DIFF
--- a/field_test.gemspec
+++ b/field_test.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 6.1"
   spec.add_dependency "browser", ">= 2"
   spec.add_dependency "rice", ">= 4.0.2"
+  spec.add_dependency "device_detector", ">= 1"
 end

--- a/lib/field_test/experiment.rb
+++ b/lib/field_test/experiment.rb
@@ -50,6 +50,9 @@ module FieldTest
       end
       membership.participant_type = participant.type if membership.respond_to?(:participant_type=)
       membership.participant_id = participant.id if membership.respond_to?(:participant_id=)
+      if membership.properties["tech_properties"].nil? && options[:tech_properties].present?
+        membership.properties["tech_properties"] = options[:tech_properties]
+      end
 
       if membership.changed? && (!closed? || membership.persisted?)
         begin

--- a/lib/field_test/helpers.rb
+++ b/lib/field_test/helpers.rb
@@ -1,3 +1,5 @@
+require "device_detector"
+
 module FieldTest
   module Helpers
     def field_test(experiment, **options)
@@ -18,8 +20,26 @@ module FieldTest
 
         options[:exclude] ||= FieldTest.excluded_ips.any? { |ip| ip.include?(request.remote_ip) }
 
+        client = DeviceDetector.new(request.user_agent)
+        device_type =
+          case client.device_type
+          when "smartphone"
+            "Mobile"
+          when "tv"
+            "TV"
+          else
+            client.device_type.try(:titleize)
+          end
+
+        tech_properties = {
+          browser: client.name,
+          os: client.os_name,
+          device_type: device_type
+        }
+
         options[:ip] = request.remote_ip
         options[:user_agent] = request.user_agent
+        options[:tech_properties] = tech_properties
       end
 
       # don't update variant when passed via params

--- a/lib/generators/field_test/templates/memberships.rb.tt
+++ b/lib/generators/field_test/templates/memberships.rb.tt
@@ -7,6 +7,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.string :variant
       t.datetime :created_at
       t.boolean :converted, default: false
+      t.json :properties, default: {}, null: false
     end
 
     add_index :field_test_memberships, [:participant_type, :participant_id, :experiment],

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -113,6 +113,46 @@ class ControllerTest < ActionDispatch::IntegrationTest
     assert_includes membership.events.pluck(:name), "signed_up", "other_goal"
   end
 
+  def test_recording_tech_properties_when_entering_an_experiment
+    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Firefox/78.0"
+    get users_url, headers: {"HTTP_USER_AGENT" => user_agent}
+    assert_response :success
+
+    membership = FieldTest::Membership.last
+    assert_equal(
+      {
+        "tech_properties" => {
+          "browser" => "Firefox",
+          "os" => "Mac",
+          "device_type" => "Desktop"
+        }
+      },
+      membership.properties
+    )
+  end
+
+  def test_does_not_override_tech_properties
+    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Firefox/78.0"
+    get users_url, headers: {"HTTP_USER_AGENT" => user_agent}
+    assert_response :success
+
+    user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Chrome/78.0"
+    get users_url, headers: {"HTTP_USER_AGENT" => user_agent}
+    assert_response :success
+
+    membership = FieldTest::Membership.last
+    assert_equal(
+      {
+        "tech_properties" => {
+          "browser" => "Firefox",
+          "os" => "Mac",
+          "device_type" => "Desktop"
+        }
+      },
+      membership.properties
+    )
+  end
+
   def get(url, **options)
     options[:headers] ||= {}
     options[:headers]["HTTP_USER_AGENT"] ||= "Mozilla/5.0"

--- a/test/experiment_test.rb
+++ b/test/experiment_test.rb
@@ -73,4 +73,34 @@ class ExperimentTest < Minitest::Test
     assert_equal ["red", "green", "blue"], experiment.variants
     assert_equal "red", experiment.control
   end
+
+  def test_tech_properties_first_time_saves_them
+    experiment = FieldTest::Experiment.find(:button_color)
+    tech_properties = {
+      "browser" => "Firefox",
+      "os" => "Mac OS X",
+      "device_type" => "Desktop"
+    }
+    experiment.variant("user123", tech_properties:)
+    membership = FieldTest::Membership.last
+
+    assert_equal tech_properties, membership.properties["tech_properties"]
+  end
+
+  def test_tech_properties_second_time_does_not_overwrite_them
+    experiment = FieldTest::Experiment.find(:button_color)
+    tech_properties = {
+      "browser" => "Firefox",
+      "os" => "Mac OS X",
+      "device_type" => "Desktop"
+    }
+    experiment.variant("user123", tech_properties:)
+    experiment.variant("user123", tech_properties: {})
+
+    assert_equal 1, FieldTest::Membership.count
+
+    membership = FieldTest::Membership.last
+
+    assert_equal tech_properties, membership.properties["tech_properties"]
+  end
 end

--- a/test/internal/db/schema.rb
+++ b/test/internal/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define do
     t.string :variant
     t.datetime :created_at
     t.boolean :converted, default: false
+    t.json :properties, default: {}, null: false
   end
 
   add_index :field_test_memberships, [:participant_type, :participant_id, :experiment], unique: true, name: "index_field_test_memberships_on_participant"


### PR DESCRIPTION
Closes https://linear.app/onramp-funds/issue/ORF-6401

# Description

This PR captures device properties of users when they become participants in an experiment. These include:

* Browser
* Operating system
* Device type 

These properties are gathered using the [device_detector gem](https://github.com/podigee/device_detector/), which is also used in Ahoy. The changes also ensure that these properties are not overwritten once set.
