### PR TITLE
Display device type on experiments show page

### DIFF
--- a/app/views/field_test/experiments/show.html.erb
+++ b/app/views/field_test/experiments/show.html.erb
@@ -17,6 +17,7 @@
       <th style="width: 20%;">Variant</th>
       <th style="width: 20%;">Converted</th>
       <th style="width: 20%;">Started</th>
+      <th style="width: 20%;">Device Type</th>
     </tr>
   </thead>
   <tbody>
@@ -49,6 +50,7 @@
             <%= membership.created_at.to_formatted_s(:short) %>
           <% end %>
         </td>
+        <td><%= membership.properties.dig("tech_properties", "device_type") %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Closes https://linear.app/onramp-funds/issue/ORF-6403

This PR introduces changes to the `app/views/field_test/experiments/show.html.erb` file, specifically adding a new column to the table for "Device Type". This column displays the device type for each membership entry in the field test experiment. 